### PR TITLE
Add gtmOnSuccess call to fix sequencing.

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -920,6 +920,7 @@ var cjData = {
 
 }
 setInWindow("cj", cjData, true);
+data.gtmOnSuccess();
 
 
 ___WEB_PERMISSIONS___


### PR DESCRIPTION
The missing data.gtmOnSuccess caused the tag to never finish running. As a result the sequencing did not work correctly, as the cleanup tag never got triggered.